### PR TITLE
Add services page with tabs and accordions

### DIFF
--- a/ventori-astro/src/components/BaseHead.astro
+++ b/ventori-astro/src/components/BaseHead.astro
@@ -1,0 +1,57 @@
+---
+// Import the global.css file here so that it is included on
+// all pages through the use of the <BaseHead /> component.
+import '../styles/global.css';
+import type { ImageMetadata } from 'astro';
+import FallbackImage from '../assets/blog-placeholder-1.jpg';
+import { SITE_TITLE } from '../consts';
+
+interface Props {
+	title: string;
+	description: string;
+	image?: ImageMetadata;
+}
+
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+
+const { title, description, image = FallbackImage } = Astro.props;
+---
+
+<!-- Global Metadata -->
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+<link rel="sitemap" href="/sitemap-index.xml" />
+<link
+	rel="alternate"
+	type="application/rss+xml"
+	title={SITE_TITLE}
+	href={new URL('rss.xml', Astro.site)}
+/>
+<meta name="generator" content={Astro.generator} />
+
+<!-- Font preloads -->
+<link rel="preload" href="/fonts/atkinson-regular.woff" as="font" type="font/woff" crossorigin />
+<link rel="preload" href="/fonts/atkinson-bold.woff" as="font" type="font/woff" crossorigin />
+
+<!-- Canonical URL -->
+<link rel="canonical" href={canonicalURL} />
+
+<!-- Primary Meta Tags -->
+<title>{title}</title>
+<meta name="title" content={title} />
+<meta name="description" content={description} />
+
+<!-- Open Graph / Facebook -->
+<meta property="og:type" content="website" />
+<meta property="og:url" content={Astro.url} />
+<meta property="og:title" content={title} />
+<meta property="og:description" content={description} />
+<meta property="og:image" content={new URL(image.src, Astro.url)} />
+
+<!-- Twitter -->
+<meta property="twitter:card" content="summary_large_image" />
+<meta property="twitter:url" content={Astro.url} />
+<meta property="twitter:title" content={title} />
+<meta property="twitter:description" content={description} />
+<meta property="twitter:image" content={new URL(image.src, Astro.url)} />

--- a/ventori-astro/src/components/FormattedDate.astro
+++ b/ventori-astro/src/components/FormattedDate.astro
@@ -1,0 +1,17 @@
+---
+interface Props {
+	date: Date;
+}
+
+const { date } = Astro.props;
+---
+
+<time datetime={date.toISOString()}>
+	{
+		date.toLocaleDateString('en-us', {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+		})
+	}
+</time>

--- a/ventori-astro/src/components/Header.astro
+++ b/ventori-astro/src/components/Header.astro
@@ -12,7 +12,7 @@
 
     <nav class="nav" aria-label="Main navigation">
       <a href="/" class="nav-link">Home</a>
-      <a href="#services" class="nav-link">Services</a>
+      <a href="/services" class="nav-link">Services</a>
       <a href="#services" class="nav-link">Insight Hub</a>
       <a href="#training" class="nav-link">Career</a>
       <a href="/about" class="nav-link">About</a>
@@ -28,7 +28,7 @@
   <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
    
     <a href="#home" class="mobile-link">Home</a>
-    <a href="#services" class="mobile-link">Services</a>
+    <a href="/services" class="mobile-link">Services</a>
     <a href="#usecases" class="mobile-link">Use Cases</a>
     <a href="#process" class="mobile-link">Process</a>
     <a href="#training" class="mobile-link">Training</a>
@@ -56,7 +56,7 @@
       mobileBtn.addEventListener('click', () => {
         mobileMenu.classList.contains('open') ? closeMenu() : openMenu();
       });
-      mobileMenu.querySelectorAll('a[href^="#"]').forEach(a => {
+      mobileMenu.querySelectorAll('a').forEach(a => {
         a.addEventListener('click', closeMenu);
       });
       // Close menu if switching to desktop

--- a/ventori-astro/src/pages/services.astro
+++ b/ventori-astro/src/pages/services.astro
@@ -1,0 +1,152 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+import Accordion from "../components/Accordion.astro";
+import "../styles/services.css";
+---
+<BaseLayout title="Ventori Services – Explore Our Offerings" description="From foundational training to full AI implementation, discover how Ventori Data Solutions can accelerate your AI & automation journey.">
+  <Header />
+  <main>
+    <section class="services-hero">
+      <div class="container">
+        <h1 class="h1">Explore Our Services</h1>
+        <p class="lead muted">
+          From foundational training to full AI implementation, discover how Ventori Data Solutions can accelerate your AI & automation journey.
+        </p>
+      </div>
+    </section>
+
+    <section class="services-overview">
+      <div class="container">
+        <div class="services-tabs" role="tablist">
+          <button class="services-tab active" type="button" role="tab" aria-selected="true" data-tab="training">Training</button>
+          <button class="services-tab" type="button" role="tab" aria-selected="false" data-tab="workshops">Workshops</button>
+          <button class="services-tab" type="button" role="tab" aria-selected="false" data-tab="implementation">Implementation</button>
+          <button class="services-tab" type="button" role="tab" aria-selected="false" data-tab="consulting">Consulting</button>
+        </div>
+
+        <div id="training" class="category-panel active" role="tabpanel">
+          <div class="accordion-group">
+            <Accordion title="Beginner Program">
+              <p class="muted">
+                Kickstart your AI journey with a comprehensive introduction to machine learning, automation concepts, and ethical considerations. Includes hands-on exercises and optional certification.
+              </p>
+            </Accordion>
+            <Accordion title="Intermediate Program">
+              <p class="muted">
+                Deepen your skills with practical AI projects, advanced automation workflows, and integration techniques. Includes exam and certification.
+              </p>
+            </Accordion>
+            <Accordion title="Expert Program">
+              <p class="muted">
+                Master AI strategy, compliance (EU AI Act), and building production-ready AI systems. Includes capstone project and professional certification.
+              </p>
+            </Accordion>
+          </div>
+        </div>
+
+        <div id="workshops" class="category-panel" role="tabpanel">
+          <div class="accordion-group">
+            <Accordion title="RAG System Workshop">
+              <p class="muted">
+                Learn to build a Retrieval-Augmented Generation system using no-code tools like n8n and vector databases. Includes live demos and your own working pipeline.
+              </p>
+            </Accordion>
+            <Accordion title="Automation Workflow Lab">
+              <p class="muted">
+                Design and deploy automated workflows for your business processes using tools like n8n, Qdrant, and Ollama.
+              </p>
+            </Accordion>
+          </div>
+        </div>
+
+        <div id="implementation" class="category-panel" role="tabpanel">
+          <div class="accordion-group">
+            <Accordion title="Custom RAG System">
+              <p class="muted">
+                We design, build, and deploy a RAG system tailored to your data and business needs, fully hosted on-prem or in your cloud.
+              </p>
+            </Accordion>
+            <Accordion title="Workflow Automation Integration">
+              <p class="muted">
+                We analyse your processes and implement automation workflows that integrate seamlessly with your existing tools.
+              </p>
+            </Accordion>
+          </div>
+        </div>
+
+        <div id="consulting" class="category-panel" role="tabpanel">
+          <div class="accordion-group">
+            <Accordion title="AI Strategy Consulting">
+              <p class="muted">
+                Work with our experts to define your AI adoption roadmap, identify high-impact use cases, and ensure compliance with regulations.
+              </p>
+            </Accordion>
+            <Accordion title="Technology Advisory">
+              <p class="muted">
+                Independent advice on AI platforms, tools, and architectures to fit your business requirements and budget.
+              </p>
+            </Accordion>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+  <Footer />
+
+  <script client:load>
+    const tabs = document.querySelectorAll('.services-tab');
+    const panels = document.querySelectorAll('.category-panel');
+    tabs.forEach(tab => {
+      tab.addEventListener('click', () => {
+        const target = tab.getAttribute('data-tab');
+        tabs.forEach(t => {
+          t.classList.remove('active');
+          t.setAttribute('aria-selected', 'false');
+        });
+        tab.classList.add('active');
+        tab.setAttribute('aria-selected', 'true');
+        panels.forEach(panel => {
+          panel.classList.toggle('active', panel.id === target);
+        });
+      });
+    });
+
+    document.querySelectorAll('.accordion-group').forEach(group => {
+      const accordions = Array.from(group.querySelectorAll('.accordion'));
+      const closeAcc = acc => {
+        acc.classList.remove('open');
+        const btn = acc.querySelector('.accordion-button');
+        const content = acc.querySelector('.accordion-content');
+        if (btn) btn.setAttribute('aria-expanded', 'false');
+        if (content) content.style.maxHeight = 0;
+      };
+      const openAcc = acc => {
+        acc.classList.add('open');
+        const btn = acc.querySelector('.accordion-button');
+        const content = acc.querySelector('.accordion-content');
+        if (btn) btn.setAttribute('aria-expanded', 'true');
+        if (content) content.style.maxHeight = content.scrollHeight + 'px';
+      };
+      accordions.forEach(acc => {
+        const btn = acc.querySelector('.accordion-button');
+        const content = acc.querySelector('.accordion-content');
+        if (acc.classList.contains('open') && content) {
+          content.style.maxHeight = content.scrollHeight + 'px';
+        }
+        btn?.addEventListener('click', () => {
+          const isOpen = acc.classList.contains('open');
+          accordions.forEach(closeAcc);
+          if (!isOpen) openAcc(acc);
+        });
+      });
+    });
+
+    window.addEventListener('resize', () => {
+      document.querySelectorAll('.accordion.open .accordion-content').forEach(c => {
+        c.style.maxHeight = c.scrollHeight + 'px';
+      });
+    });
+  </script>
+</BaseLayout>

--- a/ventori-astro/src/styles/services.css
+++ b/ventori-astro/src/styles/services.css
@@ -1,0 +1,71 @@
+.services-hero {
+  padding-top: 80px; /* account for fixed header */
+  background: var(--bg-secondary);
+  padding: 4rem 0;
+  text-align: center;
+}
+
+.services-hero p {
+  color: var(--text-muted);
+  max-width: 60ch;
+  margin: 0 auto;
+}
+
+.services-overview {
+  padding: 4rem 0;
+}
+
+.services-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  border-bottom: 2px solid var(--bg-accent);
+}
+
+.services-tab {
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  background: none;
+  border: none;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color var(--transition), border-color var(--transition);
+}
+
+.services-tab:hover,
+.services-tab:focus {
+  color: var(--accent);
+}
+
+.services-tab.active {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.category-panel {
+  display: none;
+}
+
+.category-panel.active {
+  display: block;
+  margin-top: 2rem;
+}
+
+.accordion-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+@media (max-width: 768px) {
+  .services-tabs {
+    flex-direction: column;
+    align-items: center;
+  }
+  .services-tab {
+    width: 100%;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary
- convert prototype services page to Astro with tabbed categories and accordions
- add page-specific styling and hook navigation to `/services`
- restore missing BaseHead and FormattedDate components for blog pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not find requested image `../../assets/blog-placeholder-about.jpg`)*

------
https://chatgpt.com/codex/tasks/task_e_68a4aa159418832e9ab9e16475b6124e