### PR TITLE
Add accessible accordion ids and hidden toggling

### DIFF
--- a/ventori-astro/src/components/Accordion.astro
+++ b/ventori-astro/src/components/Accordion.astro
@@ -1,12 +1,27 @@
 ---
+import { randomUUID } from 'node:crypto';
+
 const { title, initiallyOpen = false } = Astro.props;
+const buttonId = `accordion-btn-${randomUUID()}`;
+const contentId = `${buttonId}-content`;
 ---
 <div class={`accordion${initiallyOpen ? " open" : ""}`} data-accordion>
-  <button class="accordion-button" aria-expanded={initiallyOpen ? "true" : "false"}>
+  <button
+    id={buttonId}
+    class="accordion-button"
+    aria-expanded={initiallyOpen ? "true" : "false"}
+    aria-controls={contentId}
+  >
     <h3 class="h4">{title}</h3>
     <i class="fas fa-chevron-down accordion-icon"></i>
   </button>
-  <div class="accordion-content" role="region">
+  <div
+    id={contentId}
+    class="accordion-content"
+    role="region"
+    aria-labelledby={buttonId}
+    hidden={!initiallyOpen}
+  >
     <div class="accordion-inner">
       <slot />
     </div>

--- a/ventori-astro/src/components/FAQ.astro
+++ b/ventori-astro/src/components/FAQ.astro
@@ -71,22 +71,32 @@ import Accordion from "./Accordion.astro";
       const content = acc.querySelector('.accordion-content');
       acc.classList.remove('open');
       if (btn) btn.setAttribute('aria-expanded','false');
-      if (content) content.style.maxHeight = 0;
+      if (content) {
+        content.style.maxHeight = 0;
+        content.setAttribute('hidden', '');
+      }
     };
     const openAcc = (acc) => {
       const btn = acc.querySelector('.accordion-button');
       const content = acc.querySelector('.accordion-content');
       acc.classList.add('open');
       if (btn) btn.setAttribute('aria-expanded','true');
-      if (content) content.style.maxHeight = content.scrollHeight + 'px';
+      if (content) {
+        content.removeAttribute('hidden');
+        content.style.maxHeight = content.scrollHeight + 'px';
+      }
     };
     // init
     accordions.forEach(acc => {
       const content = acc.querySelector('.accordion-content');
-      if (acc.classList.contains('open')) {
-        content.style.maxHeight = content.scrollHeight + 'px';
-      } else {
-        content.style.maxHeight = 0;
+      if (content) {
+        if (acc.classList.contains('open')) {
+          content.removeAttribute('hidden');
+          content.style.maxHeight = content.scrollHeight + 'px';
+        } else {
+          content.setAttribute('hidden', '');
+          content.style.maxHeight = 0;
+        }
       }
       const btn = acc.querySelector('.accordion-button');
       btn?.addEventListener('click', () => {

--- a/ventori-astro/src/pages/services.astro
+++ b/ventori-astro/src/pages/services.astro
@@ -196,20 +196,32 @@ import "../styles/services.css";
         const btn = acc.querySelector('.accordion-button');
         const content = acc.querySelector('.accordion-content');
         if (btn) btn.setAttribute('aria-expanded', 'false');
-        if (content) content.style.maxHeight = 0;
+        if (content) {
+          content.style.maxHeight = 0;
+          content.setAttribute('hidden', '');
+        }
       };
       const openAcc = acc => {
         acc.classList.add('open');
         const btn = acc.querySelector('.accordion-button');
         const content = acc.querySelector('.accordion-content');
         if (btn) btn.setAttribute('aria-expanded', 'true');
-        if (content) content.style.maxHeight = content.scrollHeight + 'px';
+        if (content) {
+          content.removeAttribute('hidden');
+          content.style.maxHeight = content.scrollHeight + 'px';
+        }
       };
       accordions.forEach(acc => {
         const btn = acc.querySelector('.accordion-button');
         const content = acc.querySelector('.accordion-content');
-        if (acc.classList.contains('open') && content) {
-          content.style.maxHeight = content.scrollHeight + 'px';
+        if (content) {
+          if (acc.classList.contains('open')) {
+            content.removeAttribute('hidden');
+            content.style.maxHeight = content.scrollHeight + 'px';
+          } else {
+            content.setAttribute('hidden', '');
+            content.style.maxHeight = 0;
+          }
         }
         btn?.addEventListener('click', () => {
           const isOpen = acc.classList.contains('open');


### PR DESCRIPTION
## Summary
- ensure Accordion buttons have unique ids and link to their content via aria attributes
- add aria-labelledby and initial hidden state for accordion content
- toggle hidden attribute for collapsed accordion content in FAQ and Services scripts

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Could not find requested image `../../assets/blog-placeholder-4.jpg`)


------
https://chatgpt.com/codex/tasks/task_e_68a4b5756928832e98c57729f9e6b716